### PR TITLE
fix(core): PHPMNT-394 Remove runtime dependency on lodash

### DIFF
--- a/src/cache-key-resolver.ts
+++ b/src/cache-key-resolver.ts
@@ -1,5 +1,6 @@
-import { noop } from 'lodash';
 import shallowEqual from 'shallowequal';
+
+function noop(): void {} // tslint:disable-line:no-empty
 
 import {
     isRootCacheKeyMap,


### PR DESCRIPTION
Jira: [PHPMNT-394](https://bigcommercecloud.atlassian.net/browse/PHPMNT-394)

## What/Why?
We import `noop` from `lodash`, but lodash isn't in `dependencies` — it only shows up transitively via dev deps. Consumers without lodash crash with `Cannot find module 'lodash'`. Replaced it with a local one-liner.

## Rollout/Rollback
Merge / revert

## Testing
Lint and all 24 tests pass. Reproduced the crash in a clean install without lodash; module loads fine with this change

[PHPMNT-394]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ