### PR TITLE
fix(core): PHPMNT-394 Clean up internal maps when cache keys expire

### DIFF
--- a/src/cache-key-maps.ts
+++ b/src/cache-key-maps.ts
@@ -19,6 +19,6 @@ export function isTerminalCacheKeyMap(map: ChildCacheKeyMap): map is TerminalCac
     return map.hasOwnProperty('cacheKey');
 }
 
-export function isRootCacheKeyMap(map: RootCacheKeyMap | ChildCacheKeyMap): map is RootCacheKeyMap {
+export function isChildCacheKeyMap(map: RootCacheKeyMap | ChildCacheKeyMap): map is ChildCacheKeyMap {
     return map.hasOwnProperty('parentMap');
 }

--- a/src/cache-key-resolver.spec.ts
+++ b/src/cache-key-resolver.spec.ts
@@ -99,6 +99,42 @@ describe('CacheKeyResolver', () => {
         expect(resolver.getKey('hello', 'world')).toEqual('4');
     });
 
+    it('cleans up internal maps when cache keys expire', () => {
+        const resolver = new CacheKeyResolver({ maxSize: 1 });
+
+        for (let index = 0; index < 100; index++) {
+            resolver.getKey(`arg${index}`, 'second');
+        }
+
+        // Only the branch for the most recent call should remain
+        expect((resolver as any)._map.maps.length).toEqual(1);
+    });
+
+    it('keeps cache keys that share arguments with an expired key', () => {
+        const resolver = new CacheKeyResolver({ maxSize: 2 });
+
+        expect(resolver.getKey('a')).toEqual('1');
+        expect(resolver.getKey('a', 'b')).toEqual('2');
+
+        // This call expires the key for ('a'), which shares a path with ('a', 'b')
+        expect(resolver.getKey('c')).toEqual('3');
+
+        expect(resolver.getKey('a', 'b')).toEqual('2');
+    });
+
+    it('keeps sibling cache keys when a key expires', () => {
+        const resolver = new CacheKeyResolver({ maxSize: 2 });
+
+        expect(resolver.getKey('x', 'y')).toEqual('1');
+        expect(resolver.getKey('x', 'z')).toEqual('2');
+
+        // This call expires the key for ('x', 'y'), which shares its first
+        // argument with ('x', 'z')
+        expect(resolver.getKey('c')).toEqual('3');
+
+        expect(resolver.getKey('x', 'z')).toEqual('2');
+    });
+
     it('returns cache key used count', () => {
         const resolver = new CacheKeyResolver();
 

--- a/src/cache-key-resolver.ts
+++ b/src/cache-key-resolver.ts
@@ -2,7 +2,7 @@ import { noop } from 'lodash';
 import shallowEqual from 'shallowequal';
 
 import {
-    isRootCacheKeyMap,
+    isChildCacheKeyMap,
     isTerminalCacheKeyMap,
     ChildCacheKeyMap,
     IntermediateCacheKeyMap,
@@ -156,21 +156,37 @@ export default class CacheKeyResolver {
             return;
         }
 
+        const { cacheKey } = map;
+
         this._removeMap(map);
-        this._options.onExpire(map.cacheKey);
+        this._options.onExpire(cacheKey);
     }
 
     private _removeMap(map: ChildCacheKeyMap): void {
-        if (!map.parentMap) {
+        // If the map still has children, it is part of the path to other
+        // cached entries. Only remove its own cache key so that the other
+        // entries remain resolvable.
+        if (map.maps.length) {
+            delete (map as Partial<TerminalCacheKeyMap>).cacheKey;
+
             return;
         }
 
-        map.parentMap.maps.splice(map.parentMap.maps.indexOf(map), 1);
+        const { parentMap } = map;
 
-        if (isRootCacheKeyMap(map.parentMap)) {
+        if (!parentMap) {
             return;
         }
 
-        this._removeMap(map.parentMap);
+        parentMap.maps.splice(parentMap.maps.indexOf(map), 1);
+
+        // Also remove ancestors that no longer lead to any cache key,
+        // otherwise they would accumulate indefinitely as keys expire.
+        if (parentMap.maps.length === 0 &&
+            isChildCacheKeyMap(parentMap) &&
+            !isTerminalCacheKeyMap(parentMap)
+        ) {
+            this._removeMap(parentMap);
+        }
     }
 }


### PR DESCRIPTION
Jira: [PHPMNT-394](https://bigcommercecloud.atlassian.net/browse/PHPMNT-394)

## What/Why?
`isRootCacheKeyMap` had inverted logic (it returned true for *child* maps), so when a cache key expired we never cleaned up its intermediate maps, the internal tree would grow forever. With `maxSize: 1` and 1000 unique two-arg calls, all 1000 branches were retained

Fixes:
- Renamed the guard to `isChildCacheKeyMap`, matching what it actually checks.
- `_removeMap` now removes empty ancestor maps, but leaves maps that still lead to other cache keys (shared argument prefixes, sibling entries) untouched.

## Rollout/Rollback
Merge / revert

## Testing
Tests pass

[PHPMNT-394]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ