### PR TITLE
fix(core): PHPMNT-394 Evict least recently used cache key, not oldest

### DIFF
--- a/src/cache-key-resolver.spec.ts
+++ b/src/cache-key-resolver.spec.ts
@@ -135,6 +135,22 @@ describe('CacheKeyResolver', () => {
         expect(resolver.getKey('x', 'z')).toEqual('2');
     });
 
+    it('does not expire a cache key that was recently reused', () => {
+        const resolver = new CacheKeyResolver({ maxSize: 2 });
+
+        expect(resolver.getKey('a')).toEqual('1');
+        expect(resolver.getKey('b')).toEqual('2');
+
+        // Reusing ('a') makes ('b') the least recently used key
+        expect(resolver.getKey('a')).toEqual('1');
+
+        // This call expires ('b'), not ('a')
+        expect(resolver.getKey('c')).toEqual('3');
+
+        expect(resolver.getKey('a')).toEqual('1');
+        expect(resolver.getKey('b')).not.toEqual('2');
+    });
+
     it('returns cache key used count', () => {
         const resolver = new CacheKeyResolver();
 

--- a/src/cache-key-resolver.ts
+++ b/src/cache-key-resolver.ts
@@ -141,11 +141,13 @@ export default class CacheKeyResolver {
 
         const index = this._usedMaps.indexOf(recentlyUsedMap);
 
-        this._usedMaps.splice(
-            index === -1 ? 0 : index,
-            index === -1 ? 0 : 1,
-            recentlyUsedMap
-        );
+        // Move the most recently used map to the front of the stack so that
+        // the map at the end is always the least recently used one.
+        if (index !== -1) {
+            this._usedMaps.splice(index, 1);
+        }
+
+        this._usedMaps.unshift(recentlyUsedMap);
 
         if (this._usedMaps.length <= this._options.maxSize) {
             return;


### PR DESCRIPTION
Jira: [PHPMNT-394](https://bigcommercecloud.atlassian.net/browse/PHPMNT-394)

## What/Why?
Eviction with `maxSize` was FIFO, not LRU as the docs and comments claim: reusing a cached entry didn't refresh its position in the usage stack, so frequently-used entries got evicted purely by insertion order. Now a reused entry moves to the front of the stack, so the entry evicted is actually the least recently used one.

## Rollout/Rollback
Merge / revert

## Testing
Tests pass

[PHPMNT-394]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ