### PR TITLE
chore(core): PHPMNT-394 Remove Omit type polyfill

### DIFF
--- a/src/memoize.ts
+++ b/src/memoize.ts
@@ -2,7 +2,6 @@ import lodashMemoize from 'lodash.memoize'; // tslint:disable-line:match-default
 import shallowEqual from 'shallowequal';
 
 import CacheKeyResolver from './cache-key-resolver';
-import { Omit } from './types';
 
 export interface MemoizeOptions {
     maxSize?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,1 +1,0 @@
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;


### PR DESCRIPTION
Jira: [PHPMNT-394](https://bigcommercecloud.atlassian.net/browse/PHPMNT-394)

## What/Why?
`src/types.ts` polyfills `Omit`, which has been built into TypeScript since 3.5 (we're on 5.x)

This deletes the file and switched to the built-in. Teh type wasn't exported so there's no public API change.

## Rollout/Rollback
Merge / revert

## Testing
CI on this PR, tests pass

[PHPMNT-394]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ