### PR TITLE
chore(common): PHPMNT-394 Require Node 26 and npm 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ aliases:
   - &node_executor
     executor:
       name: node/node
-      node-version: "20.19"
+      node-version: "26.5"
 
 version: 2.1
 

--- a/package.json
+++ b/package.json
@@ -17,11 +17,15 @@
     "url": "https://github.com/bigcommerce/memoize-js/issues"
   },
   "homepage": "https://github.com/bigcommerce/memoize-js",
+  "engines": {
+    "node": ">=26",
+    "npm": ">=11"
+  },
   "scripts": {
     "prebuild": "rm -rf lib",
     "build": "tsc --outDir lib --project tsconfig.json",
-    "lint": "eslint 'src/**/*.ts' && tsc --noEmit",
-    "prepare": "check-node-version --node '>=10' --npm '>=6' && npm run build",
+"lint": "eslint 'src/**/*.ts' && tsc --noEmit",
+    "prepare": "check-node-version --node '>=26' --npm '>=11' && npm run build",
     "prerelease": "git fetch --tags && npm run validate-commits && npm run lint && npm test",
     "release": "standard-version",
     "postrelease": "npm publish --access public && git push --follow-tags",


### PR DESCRIPTION
Jira: [PHPMNT-394](https://bigcommercecloud.atlassian.net/browse/PHPMNT-394)

## What/Why?
Requires Node 26 and npm 11 for working on this repo:

- `engines` field set to `node >=26`, `npm >=11`
- The `prepare` script's `check-node-version` gate raised from Node 10/npm 6 to Node 26/npm 11
- CircleCI executor bumped from Node `20.19` to `26.5` to match (CI runs `npm ci`, which triggers the `prepare` gate, so it must run on Node 26)

Verified under Node 26.5.0 / npm 11.17.0: clean `npm ci`, lint, tests, and build all pass.

Note: `engines` is also read by consumers of the published package — anyone installing on Node < 26 (including current LTS lines) will see an `EBADENGINE` warning. If that is not intended, the `engines` field can be kept lower (e.g. `>=20`) while only the `prepare` gate enforces Node 26 for development.

## Rollout/Rollback
Merge / revert

## Testing
`npm run prepare` (version check + build) passes locally on Node 26.5.0; CI on this PR exercises the new executor.

[PHPMNT-394]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ