### PR TITLE
chore(common): PHPMNT-394 Modernise packaging

### DIFF
--- a/jest-config.js
+++ b/jest-config.js
@@ -7,6 +7,10 @@ module.exports = {
         'jsx',
         'json',
     ],
+    testPathIgnorePatterns: [
+        '/node_modules/',
+        '<rootDir>/lib/',
+    ],
     setupFilesAfterEnv: [
         '<rootDir>/jest-setup.ts',
     ],

--- a/package.json
+++ b/package.json
@@ -5,12 +5,19 @@
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    }
+  },
+  "sideEffects": false,
   "files": [
     "lib/"
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/bigcommerce/memoize-js.git"
+    "url": "https://github.com/bigcommerce/memoize-js.git"
   },
   "author": "BigCommerce",
   "bugs": {
@@ -19,7 +26,7 @@
   "homepage": "https://github.com/bigcommerce/memoize-js",
   "scripts": {
     "prebuild": "rm -rf lib",
-    "build": "tsc --outDir lib --project tsconfig.json",
+"build": "tsc --outDir lib --project tsconfig.build.json",
     "lint": "eslint 'src/**/*.ts' && tsc --noEmit",
     "prepare": "check-node-version --node '>=10' --npm '>=6' && npm run build",
     "prerelease": "git fetch --tags && npm run validate-commits && npm run lint && npm test",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": [
+        "src/**/*.spec.ts"
+    ]
+}


### PR DESCRIPTION
Jira: [PHPMNT-394](https://bigcommercecloud.atlassian.net/browse/PHPMNT-394)

## What/Why?
- Add an `exports` map and `sideEffects: false` so modern bundlers can resolve and tree-shake the package properly.
- Replace the deprecated `git://` repository URL with `https`.
- Build via a new `tsconfig.build.json` that excludes spec files — we currently compile *and publish* `*.spec.js` in the tarball. Also ignore `lib/` in jest, which was silently re-running the previously compiled specs.

## Rollout/Rollback
Regular npm release; runtime code unchanged. Rollback = revert.

## Testing
`npm run build` produces `lib/` without specs, `npm pack --dry-run` shows 18 files (specs gone), tests and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PHPMNT-394]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ