### PR TITLE
test(core): PHPMNT-394 Cover memoizeOne and the isEqual option

### DIFF
--- a/jest-config.js
+++ b/jest-config.js
@@ -17,4 +17,12 @@ module.exports = {
         '\\.mock\\.ts$',
         '\\.d\\.ts$',
     ],
+    coverageThreshold: {
+        global: {
+            statements: 97,
+            branches: 90,
+            functions: 100,
+            lines: 97,
+        },
+    },
 };

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,0 +1,8 @@
+import { memoize, memoizeOne } from './index';
+
+describe('index', () => {
+    it('exposes the public API', () => {
+        expect(typeof memoize).toEqual('function');
+        expect(typeof memoizeOne).toEqual('function');
+    });
+});

--- a/src/memoize.spec.ts
+++ b/src/memoize.spec.ts
@@ -1,4 +1,4 @@
-import memoize from './memoize';
+import memoize, { memoizeOne } from './memoize';
 
 describe('memoize', () => {
     it('only calls function again if parameters are different', () => {
@@ -34,5 +34,69 @@ describe('memoize', () => {
             .toEqual(4);
         expect(Array.from(cache.values()).length)
             .toEqual(1);
+    });
+
+    it('uses custom equality function to compare arguments', () => {
+        const getId = jest.fn((person: { id: number; name: string }) => person.id);
+        const memoizedGetId = memoize(getId, {
+            isEqual: (valueA, valueB) => valueA && valueB && valueA.id === valueB.id,
+        });
+
+        memoizedGetId({ id: 1, name: 'Foo' });
+        memoizedGetId({ id: 1, name: 'Bar' });
+
+        expect(getId).toHaveBeenCalledTimes(1);
+
+        memoizedGetId({ id: 2, name: 'Foo' });
+
+        expect(getId).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns same result for same set of arguments', () => {
+        const fn = jest.fn((a: string, b: string) => ({ a, b }));
+        const memoizedFn = memoize(fn);
+
+        expect(memoizedFn('hello', 'world')).toBe(memoizedFn('hello', 'world'));
+    });
+});
+
+describe('memoizeOne', () => {
+    it('only calls function again if parameters are different', () => {
+        const add = jest.fn((a: number, b: number) => (a + b));
+        const memoizedAdd = memoizeOne(add);
+
+        memoizedAdd(1, 1);
+        memoizedAdd(1, 1);
+
+        expect(add).toHaveBeenCalledTimes(1);
+    });
+
+    it('only keeps the result of the most recent call', () => {
+        const add = jest.fn((a: number, b: number) => (a + b));
+        const memoizedAdd = memoizeOne(add);
+        const cache = memoizedAdd.cache as Map<string, number>;
+
+        memoizedAdd(1, 1);
+        memoizedAdd(2, 2);
+
+        expect(Array.from(cache.values())).toEqual([4]);
+
+        // This call is a miss again because the previous call evicted it
+        memoizedAdd(1, 1);
+
+        expect(add).toHaveBeenCalledTimes(3);
+        expect(Array.from(cache.values())).toEqual([2]);
+    });
+
+    it('uses custom equality function to compare arguments', () => {
+        const getId = jest.fn((person: { id: number; name: string }) => person.id);
+        const memoizedGetId = memoizeOne(getId, {
+            isEqual: (valueA, valueB) => valueA && valueB && valueA.id === valueB.id,
+        });
+
+        memoizedGetId({ id: 1, name: 'Foo' });
+        memoizedGetId({ id: 1, name: 'Bar' });
+
+        expect(getId).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
Jira: [PHPMNT-394](https://bigcommercecloud.atlassian.net/browse/PHPMNT-394)

## What/Why?
`memoizeOne` and the `isEqual` option had no test coverage despite being public API (`memoizeOne` is the most-used entry point in checkout-js). Adds tests for both plus a small entry-point spec, and enforces coverage thresholds (97/90/100/97) so coverage can't silently regress. No production code changes

## Rollout/Rollback
Merge / revert

## Testing
Tests pass

[PHPMNT-394]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ