### PR TITLE
fix(core): PHPMNT-394 Fall back to defaults for explicitly-undefined options

### DIFF
--- a/src/cache-key-resolver.spec.ts
+++ b/src/cache-key-resolver.spec.ts
@@ -152,6 +152,17 @@ describe('CacheKeyResolver', () => {
     expect(resolver.getKey('b')).not.toBe('2');
   });
 
+  it('falls back to default options if explicitly-undefined values are provided', () => {
+    const resolver = new CacheKeyResolver({
+      isEqual: undefined,
+      maxSize: undefined,
+      onExpire: undefined,
+    });
+
+    expect(resolver.getKey('hello')).toBe('1');
+    expect(resolver.getKey('hello')).toBe('1');
+  });
+
   it('returns cache key used count', () => {
     const resolver = new CacheKeyResolver();
 

--- a/src/cache-key-resolver.ts
+++ b/src/cache-key-resolver.ts
@@ -32,12 +32,11 @@ export default class CacheKeyResolver {
   private _options: Required<CacheKeyResolverOptions>;
 
   constructor(options?: CacheKeyResolverOptions) {
-    this._options = {
-      isEqual: shallowEqual,
-      maxSize: 0,
-      onExpire: noop,
-      ...options,
-    };
+    // Use destructuring defaults so that explicitly-undefined option
+    // values fall back to the defaults instead of overriding them
+    const { isEqual = shallowEqual, maxSize = 0, onExpire = noop } = options ?? {};
+
+    this._options = { isEqual, maxSize, onExpire };
   }
 
   getKey(...args: any[]): string {

--- a/src/memoize.spec.ts
+++ b/src/memoize.spec.ts
@@ -40,6 +40,16 @@ describe('memoize', () => {
     expect(Array.from(cache.values())).toHaveLength(1);
   });
 
+  it('falls back to default options if explicitly-undefined values are provided', () => {
+    const add = jest.fn((a: number, b: number) => a + b);
+    const memoizedAdd = memoize(add, { maxSize: undefined, isEqual: undefined });
+
+    expect(memoizedAdd(1, 1)).toBe(2);
+    expect(memoizedAdd(1, 1)).toBe(2);
+
+    expect(add).toHaveBeenCalledTimes(1);
+  });
+
   it('uses custom equality function to compare arguments', () => {
     const getId = jest.fn((person: { id: number; name: string }) => person.id);
     const memoizedGetId = memoize(getId, {

--- a/src/memoize.ts
+++ b/src/memoize.ts
@@ -12,7 +12,9 @@ export default function memoize<T extends (...args: any[]) => any>(
   fn: T,
   options?: MemoizeOptions,
 ) {
-  const { maxSize, isEqual } = { maxSize: 0, isEqual: shallowEqual, ...options };
+  // Use destructuring defaults so that explicitly-undefined option values
+  // fall back to the defaults instead of overriding them
+  const { maxSize = 0, isEqual = shallowEqual } = options ?? {};
   const cache = new Map();
   const resolver = new CacheKeyResolver({
     isEqual,


### PR DESCRIPTION
Jira: [PHPMNT-394](https://bigcommercecloud.atlassian.net/browse/PHPMNT-394)

## What/Why?
`memoize(fn, { isEqual: undefined })` crashes, and `{ maxSize: undefined }` turns off the cache limit. Passing `undefined` should behave the same as not passing the option at all, now it does

## Rollout/Rollback
Merge / revert

## Testing
Tests are added for this

[PHPMNT-394]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ