### PR TITLE
fix(core): PHPMNT-394 Reuse existing cache key map when arguments are a prefix of a previous call

### DIFF
--- a/src/cache-key-resolver.spec.ts
+++ b/src/cache-key-resolver.spec.ts
@@ -19,6 +19,30 @@ describe('CacheKeyResolver', () => {
     expect(resolver.getKey('hello', 'good', 'bye')).toBe('2');
   });
 
+  it('returns same cache key if params are a prefix of a previous call', () => {
+    const resolver = new CacheKeyResolver();
+
+    expect(resolver.getKey('hello', 'world')).toBe('1');
+    expect(resolver.getKey('hello')).toBe('2');
+    expect(resolver.getKey('hello')).toBe('2');
+    expect(resolver.getKey('hello', 'world')).toBe('1');
+  });
+
+  it('does not grow internal maps when repeatedly called with a prefix of a previous call', () => {
+    const resolver = new CacheKeyResolver();
+
+    resolver.getKey('hello', 'world');
+
+    for (let index = 0; index < 10; index++) {
+      resolver.getKey('hello');
+    }
+
+    // eslint-disable-next-line no-underscore-dangle
+    expect((resolver as any)._map.maps).toHaveLength(1);
+    // eslint-disable-next-line no-underscore-dangle
+    expect((resolver as any)._map.maps[0].maps).toHaveLength(1);
+  });
+
   it('returns same cache key if no params are provided', () => {
     const resolver = new CacheKeyResolver();
 
@@ -136,6 +160,22 @@ describe('CacheKeyResolver', () => {
     expect(resolver.getKey('x', 'z')).toBe('2');
   });
 
+  it('issues a stable cache key when an expired key is requested again', () => {
+    const resolver = new CacheKeyResolver({ maxSize: 2 });
+
+    expect(resolver.getKey('a')).toBe('1');
+    expect(resolver.getKey('a', 'b')).toBe('2');
+
+    // This call expires the key for ('a'), whose map remains in the tree
+    // because it is part of the path to ('a', 'b')
+    expect(resolver.getKey('c')).toBe('3');
+
+    // Requesting ('a') again should issue a new key once and then keep
+    // returning it
+    expect(resolver.getKey('a')).toBe('4');
+    expect(resolver.getKey('a')).toBe('4');
+  });
+
   it('does not expire a cache key that was recently reused', () => {
     const resolver = new CacheKeyResolver({ maxSize: 2 });
 
@@ -175,5 +215,18 @@ describe('CacheKeyResolver', () => {
     resolver.getKey('hello', 'world');
 
     expect(resolver.getUsedCount('hello', 'world')).toBe(2);
+  });
+
+  it('returns cache key used count for a prefix of a previous call', () => {
+    const resolver = new CacheKeyResolver();
+
+    resolver.getKey('hello', 'world');
+
+    expect(resolver.getUsedCount('hello')).toBe(0);
+
+    resolver.getKey('hello');
+
+    expect(resolver.getUsedCount('hello')).toBe(1);
+    expect(resolver.getUsedCount('hello', 'world')).toBe(1);
   });
 });

--- a/src/cache-key-resolver.ts
+++ b/src/cache-key-resolver.ts
@@ -22,7 +22,7 @@ export interface CacheKeyResolverOptions {
 interface ResolveResult {
   index: number;
   parentMap: RootCacheKeyMap | IntermediateCacheKeyMap;
-  map?: TerminalCacheKeyMap;
+  map?: ChildCacheKeyMap;
 }
 
 export default class CacheKeyResolver {
@@ -40,14 +40,26 @@ export default class CacheKeyResolver {
   }
 
   getKey(...args: any[]): string {
-    const result = this._resolveMap(...args);
-    const { index, parentMap } = result;
-    let { map } = result;
+    const { index, map: resolvedMap, parentMap } = this._resolveMap(...args);
+    let map: TerminalCacheKeyMap;
 
-    if (map?.cacheKey) {
+    if (!resolvedMap) {
+      // Cache miss: no existing map matches all the arguments, so
+      // create maps for the unmatched ones.
+      map = this._generateMap(parentMap, args.slice(index));
+    } else if (isTerminalCacheKeyMap(resolvedMap)) {
+      // Cache hit: the map already has a cache key.
+      map = resolvedMap;
       map.usedCount++;
     } else {
-      map = this._generateMap(parentMap, args.slice(index));
+      // The map matches all the arguments but has no cache key of its
+      // own, because the arguments are a prefix of a longer set of
+      // arguments seen earlier, or because its key has expired. Attach
+      // a new key to it so that the same arguments resolve to the same
+      // key from now on.
+      map = resolvedMap as TerminalCacheKeyMap;
+      map.cacheKey = `${++this._lastId}`;
+      map.usedCount = 1;
     }
 
     // Keep track of the least used map so we can remove it if the size of
@@ -60,19 +72,19 @@ export default class CacheKeyResolver {
   getUsedCount(...args: any[]): number {
     const { map } = this._resolveMap(...args);
 
-    return map ? map.usedCount : 0;
+    return map && isTerminalCacheKeyMap(map) ? map.usedCount : 0;
   }
 
   private _resolveMap(...args: any[]): ResolveResult {
     let index = 0;
     let parentMap = this._map;
 
-    // Traverse the tree to find the linked list of maps that match the
-    // arguments of the call. Each intermediate or terminal map contains a
-    // value that could be used to match with the arguments. The last map in
-    // the list (the terminal) should contain a cache key. If it can does
-    // not exist, we will return a falsy value so that the caller could
-    // handle and generate a new cache key.
+    // Traverse the tree of maps to find the map that matches the last
+    // argument of the call, and return it so that the caller can read or
+    // set its cache key. If there is no such map, return the deepest
+    // matching parent so that the caller can create the missing maps
+    // under it. Each map holds a value that is compared with the
+    // argument at its depth.
     while (parentMap.maps.length) {
       let isMatched = false;
 
@@ -87,7 +99,7 @@ export default class CacheKeyResolver {
         // quicker access
         parentMap.maps.unshift(...parentMap.maps.splice(mapIndex, 1));
 
-        if ((args.length === 0 || index === args.length - 1) && isTerminalCacheKeyMap(map)) {
+        if (args.length === 0 || index === args.length - 1) {
           return { index, map, parentMap };
         }
 

--- a/src/memoize.spec.ts
+++ b/src/memoize.spec.ts
@@ -23,6 +23,18 @@ describe('memoize', () => {
     expect(add).toHaveBeenCalledTimes(2);
   });
 
+  it('only calls function again if parameters are a prefix of a previous call', () => {
+    const join = jest.fn((...args: string[]) => args.join(','));
+    const memoizedJoin = memoize(join);
+
+    expect(memoizedJoin('a', 'b')).toBe('a,b');
+    expect(memoizedJoin('a')).toBe('a');
+    expect(memoizedJoin('a')).toBe('a');
+    expect(memoizedJoin('a', 'b')).toBe('a,b');
+
+    expect(join).toHaveBeenCalledTimes(2);
+  });
+
   it('deletes cached result when key expires', () => {
     const add = jest.fn((a: number, b: number) => a + b);
     const memoizedAdd = memoize(add, { maxSize: 1 });


### PR DESCRIPTION
Jira: [PHPMNT-394](https://bigcommercecloud.atlassian.net/browse/PHPMNT-394)

## What/Why?
Calling a memoized function with a prefix of arguments it has already seen never hits the cache, and each call leaks memory:

```ts
memoized('a', 'b'); // fn runs
memoized('a');      // fn runs
memoized('a');      // fn runs again — and on every call after this
```

Cause: the cache key lives on the last node of an argument path in the internal tree. After `('a', 'b')`, node `a` exists but has no key, and the resolver treated that as "no match" — so every `('a')` call created a new node and a new key.

Fix: when the arguments match an existing node that has no key yet, attach a new key to that node instead of creating another one. Same applies when a key has expired but its node remains as a path to longer argument lists (possible since #53).

## Rollout/Rollback
Merge / revert

## Testing
Regression tests added; `npm test` and `npm run lint` pass.

Note: overlaps with #60 in `cache-key-resolver.ts` — whichever merges second needs a trivial rebase.

[PHPMNT-394]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ