### PR TITLE
test(core): PHPMNT-394 Cover onExpire callback and edge-case argument handling

### DIFF
--- a/src/cache-key-resolver.spec.ts
+++ b/src/cache-key-resolver.spec.ts
@@ -26,6 +26,16 @@ describe('CacheKeyResolver', () => {
     expect(resolver.getKey()).toBe('1');
   });
 
+  it('returns same cache key for a call with no params and a call with a single undefined param', () => {
+    const resolver = new CacheKeyResolver();
+
+    // The resolver represents the end of an argument list with an
+    // undefined value, so these two calls are indistinguishable. This
+    // test pins the current behaviour rather than mandating it.
+    expect(resolver.getKey()).toBe('1');
+    expect(resolver.getKey(undefined)).toBe('1');
+  });
+
   it('works with non-primitive params', () => {
     const resolver = new CacheKeyResolver();
     const personA = { name: 'Foo' };
@@ -97,6 +107,21 @@ describe('CacheKeyResolver', () => {
     // This call should return a new key because the previous two calls are
     // made with different sets of arguments
     expect(resolver.getKey('hello', 'world')).toBe('4');
+  });
+
+  it('notifies the caller via onExpire when a cache key expires', () => {
+    const onExpire = jest.fn();
+    const resolver = new CacheKeyResolver({ maxSize: 1, onExpire });
+
+    resolver.getKey('a');
+
+    expect(onExpire).not.toHaveBeenCalled();
+
+    // This call expires the key for ('a')
+    resolver.getKey('b');
+
+    expect(onExpire).toHaveBeenCalledTimes(1);
+    expect(onExpire).toHaveBeenCalledWith('1');
   });
 
   it('cleans up internal maps when cache keys expire', () => {

--- a/src/memoize.spec.ts
+++ b/src/memoize.spec.ts
@@ -103,4 +103,18 @@ describe('memoizeOne', () => {
 
     expect(getId).toHaveBeenCalledTimes(1);
   });
+
+  it('ignores maxSize if provided despite the type signature', () => {
+    const add = jest.fn((a: number, b: number) => a + b);
+    const memoizedAdd = memoizeOne(add, { maxSize: 5 } as any);
+
+    memoizedAdd(1, 1);
+    memoizedAdd(2, 2);
+
+    // This call is a miss because memoizeOne always keeps only the most
+    // recent result, even if a caller sneaks in a larger maxSize
+    memoizedAdd(1, 1);
+
+    expect(add).toHaveBeenCalledTimes(3);
+  });
 });


### PR DESCRIPTION
Jira: [PHPMNT-394](https://bigcommercecloud.atlassian.net/browse/PHPMNT-394)

## What/Why?
Adds missing test coverage; no production code changes:

- `onExpire` is now asserted directly on `CacheKeyResolver` with a `jest.fn()` (previously only exercised indirectly through `memoize`'s cache deletion)
- Pins the current behaviour that `getKey()` and `getKey(undefined)` share a cache key (the resolver represents "end of argument list" with an undefined value, so they are indistinguishable — the test documents rather than mandates this)
- Verifies `memoizeOne` keeps only the most recent result even if a JS caller passes `maxSize` despite the type signature omitting it

## Rollout/Rollback
Merge / revert

## Testing
Test-only change; suite passes locally (`npm test`, `npm run lint`).

Note: independent of #61 — these tests pass on master today. Merging both may need a trivial rebase in the spec files.

[PHPMNT-394]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ