### PR TITLE
fix(core): PHPMNT-394 Treat NaN arguments as equal so they can hit the cache

### DIFF
--- a/src/cache-key-resolver.spec.ts
+++ b/src/cache-key-resolver.spec.ts
@@ -60,6 +60,17 @@ describe('CacheKeyResolver', () => {
     expect(resolver.getKey(undefined)).toBe('1');
   });
 
+  it('returns same cache key for NaN params', () => {
+    const resolver = new CacheKeyResolver();
+
+    expect(resolver.getKey(NaN)).toBe('1');
+    expect(resolver.getKey(NaN)).toBe('1');
+    expect(resolver.getKey('a', NaN)).toBe('2');
+    expect(resolver.getKey('a', NaN)).toBe('2');
+    expect(resolver.getKey({ value: NaN })).toBe('3');
+    expect(resolver.getKey({ value: NaN })).toBe('3');
+  });
+
   it('works with non-primitive params', () => {
     const resolver = new CacheKeyResolver();
     const personA = { name: 'Foo' };

--- a/src/cache-key-resolver.ts
+++ b/src/cache-key-resolver.ts
@@ -1,5 +1,3 @@
-import shallowEqual from 'shallowequal';
-
 import {
   ChildCacheKeyMap,
   IntermediateCacheKeyMap,
@@ -8,6 +6,7 @@ import {
   RootCacheKeyMap,
   TerminalCacheKeyMap,
 } from './cache-key-maps';
+import isShallowEqual from './is-shallow-equal';
 
 function noop(): void {
   /* intentional no-op */
@@ -34,7 +33,7 @@ export default class CacheKeyResolver {
   constructor(options?: CacheKeyResolverOptions) {
     // Use destructuring defaults so that explicitly-undefined option
     // values fall back to the defaults instead of overriding them
-    const { isEqual = shallowEqual, maxSize = 0, onExpire = noop } = options ?? {};
+    const { isEqual = isShallowEqual, maxSize = 0, onExpire = noop } = options ?? {};
 
     this._options = { isEqual, maxSize, onExpire };
   }

--- a/src/is-shallow-equal.spec.ts
+++ b/src/is-shallow-equal.spec.ts
@@ -1,0 +1,27 @@
+import isShallowEqual from './is-shallow-equal';
+
+describe('isShallowEqual', () => {
+  it('returns true for strictly equal values', () => {
+    const object = { name: 'Foo' };
+
+    expect(isShallowEqual('hello', 'hello')).toBe(true);
+    expect(isShallowEqual(object, object)).toBe(true);
+  });
+
+  it('returns true for shallowly equal objects', () => {
+    expect(isShallowEqual({ id: 1 }, { id: 1 })).toBe(true);
+  });
+
+  it('returns false for different values', () => {
+    expect(isShallowEqual('hello', 'bye')).toBe(false);
+    expect(isShallowEqual({ id: 1 }, { id: 2 })).toBe(false);
+    expect(isShallowEqual({ id: 1 }, { id: 1, name: 'Foo' })).toBe(false);
+  });
+
+  it('treats NaN as equal to NaN', () => {
+    expect(isShallowEqual(NaN, NaN)).toBe(true);
+    expect(isShallowEqual({ value: NaN }, { value: NaN })).toBe(true);
+    expect(isShallowEqual(NaN, 1)).toBe(false);
+    expect(isShallowEqual({ value: NaN }, { value: 1 })).toBe(false);
+  });
+});

--- a/src/is-shallow-equal.ts
+++ b/src/is-shallow-equal.ts
@@ -1,0 +1,16 @@
+import shallowEqual from 'shallowequal';
+
+function compareNaN(valueA: any, valueB: any): boolean | undefined {
+  // Treat a pair of NaN values as equal, otherwise return undefined so
+  // that shallowequal falls back to its default strict-equality check.
+  return Number.isNaN(valueA) && Number.isNaN(valueB) ? true : undefined;
+}
+
+/**
+ * Compares two values shallowly, treating NaN as equal to itself. Without
+ * this, a NaN argument could never resolve to an existing cache key, so
+ * every call would create a new cache entry.
+ */
+export default function isShallowEqual(valueA: any, valueB: any): boolean {
+  return shallowEqual(valueA, valueB, compareNaN);
+}

--- a/src/memoize.spec.ts
+++ b/src/memoize.spec.ts
@@ -62,6 +62,16 @@ describe('memoize', () => {
     expect(add).toHaveBeenCalledTimes(1);
   });
 
+  it('does not call function again for NaN arguments', () => {
+    const format = jest.fn((value: number) => `${value}`);
+    const memoizedFormat = memoize(format);
+
+    expect(memoizedFormat(NaN)).toBe('NaN');
+    expect(memoizedFormat(NaN)).toBe('NaN');
+
+    expect(format).toHaveBeenCalledTimes(1);
+  });
+
   it('uses custom equality function to compare arguments', () => {
     const getId = jest.fn((person: { id: number; name: string }) => person.id);
     const memoizedGetId = memoize(getId, {

--- a/src/memoize.ts
+++ b/src/memoize.ts
@@ -1,7 +1,7 @@
 import lodashMemoize from 'lodash.memoize';
-import shallowEqual from 'shallowequal';
 
 import CacheKeyResolver from './cache-key-resolver';
+import isShallowEqual from './is-shallow-equal';
 
 export interface MemoizeOptions {
   maxSize?: number;
@@ -14,7 +14,7 @@ export default function memoize<T extends (...args: any[]) => any>(
 ) {
   // Use destructuring defaults so that explicitly-undefined option values
   // fall back to the defaults instead of overriding them
-  const { maxSize = 0, isEqual = shallowEqual } = options ?? {};
+  const { maxSize = 0, isEqual = isShallowEqual } = options ?? {};
   const cache = new Map();
   const resolver = new CacheKeyResolver({
     isEqual,


### PR DESCRIPTION
Jira: [PHPMNT-394](https://bigcommercecloud.atlassian.net/browse/PHPMNT-394)

## What/Why?
A `NaN` argument (bare, or as an object value) never hits the cache, because the default comparison uses strict equality and `NaN !== NaN`:

```ts
memoized(NaN); // fn runs, key "1"
memoized(NaN); // fn runs again, key "2", and on every call after this
```

Besides never memoizing, each call permanently adds a node to the internal key tree and an entry to the cache Map (the default `maxSize: 0` never evicts), so this is also a memory leak.

Fix: the default `isEqual` is now a small wrapper around `shallowequal` that passes a customizer treating a pair of NaNs as equal — the same semantics a `Map` key would have. A user-supplied `isEqual` is unaffected.

## Rollout/Rollback
Merge / revert

## Testing
Added some tests

[PHPMNT-394]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ