### PR TITLE
perf(core): PHPMNT-394 Avoid linear scans in LRU bookkeeping and skip no-op reordering

### DIFF
--- a/src/cache-key-resolver.ts
+++ b/src/cache-key-resolver.ts
@@ -28,7 +28,7 @@ interface ResolveResult {
 export default class CacheKeyResolver {
   private _lastId = 0;
   private _map: RootCacheKeyMap = { maps: [] };
-  private _usedMaps: TerminalCacheKeyMap[] = [];
+  private _usedMaps = new Set<TerminalCacheKeyMap>();
   private _options: Required<CacheKeyResolverOptions>;
 
   constructor(options?: CacheKeyResolverOptions) {
@@ -83,9 +83,14 @@ export default class CacheKeyResolver {
           continue;
         }
 
-        // Move the most recently used map to the top of the stack for
-        // quicker access
-        parentMap.maps.unshift(...parentMap.maps.splice(mapIndex, 1));
+        // Move the most recently used map to the top of the stack
+        // for quicker access, unless it is already at the top. The
+        // check matters because repeated calls with the same
+        // arguments always match at the top, and moving it in place
+        // would still shift the entire array twice.
+        if (mapIndex > 0) {
+          parentMap.maps.unshift(...parentMap.maps.splice(mapIndex, 1));
+        }
 
         if ((args.length === 0 || index === args.length - 1) && isTerminalCacheKeyMap(map)) {
           return { index, map, parentMap };
@@ -143,25 +148,24 @@ export default class CacheKeyResolver {
       return;
     }
 
-    const index = this._usedMaps.indexOf(recentlyUsedMap);
+    // Re-inserting the map moves it to the end of the set, so the first
+    // map in the set is always the least recently used one. Unlike an
+    // array, a set can do this without scanning or shifting the other
+    // maps.
+    this._usedMaps.delete(recentlyUsedMap);
+    this._usedMaps.add(recentlyUsedMap);
 
-    // Move the most recently used map to the front of the stack so that
-    // the map at the end is always the least recently used one.
-    if (index !== -1) {
-      this._usedMaps.splice(index, 1);
-    }
-
-    this._usedMaps.unshift(recentlyUsedMap);
-
-    if (this._usedMaps.length <= this._options.maxSize) {
+    if (this._usedMaps.size <= this._options.maxSize) {
       return;
     }
 
-    const map = this._usedMaps.pop();
+    const map = this._usedMaps.values().next().value;
 
     if (!map) {
       return;
     }
+
+    this._usedMaps.delete(map);
 
     const { cacheKey } = map;
 


### PR DESCRIPTION
Jira: [PHPMNT-394](https://bigcommercecloud.atlassian.net/browse/PHPMNT-394)

## What/Why?
Two behaviour-preserving optimisations on the `getKey` hot path:

1. **LRU bookkeeping is now a `Set` instead of an array.** The array version did `indexOf` + `splice` + `unshift` on every call — three O(maxSize) scans/shifts. A `Set` re-insertion moves the entry to the end in O(1), and the least recently used entry is simply the first one.
2. **Skip the "move to front" reshuffle when the matched map is already at the front.** Repeated calls with the same arguments always match at the front, and the unconditional `unshift(...splice(...))` shifted the whole sibling array twice for nothing.

Rough benchmark (200k `getKey` calls, 1000 cached keys, `maxSize: 1000`):

| Scenario | before | after |
|---|---|---|
| repeated same arguments | 471 ms | 270 ms |
| cycling through all keys (always hits the LRU entry) | 1207 ms | 1022 ms |

## Rollout/Rollback
Merge / revert

## Testing
The tests still pass!

[PHPMNT-394]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ