### PR TITLE
chore(common): PHPMNT-394 Upgrade to Node.js to v26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ aliases:
   - &node_executor
     executor:
       name: node/node
-      node-version: "20.19"
+      node-version: "26.5"
 
 version: 2.1
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prebuild": "rm -rf lib",
     "build": "tsc --outDir lib --project tsconfig.json",
     "lint": "eslint 'src/**/*.ts' && tsc --noEmit",
-    "prepare": "check-node-version --node '>=10' --npm '>=6' && npm run build",
+    "prepare": "check-node-version --node '>=26' --npm '>=11' && npm run build",
     "prerelease": "git fetch --tags && npm run validate-commits && npm run lint && npm test",
     "release": "standard-version",
     "postrelease": "npm publish --access public && git push --follow-tags",


### PR DESCRIPTION
Jira: [PHPMNT-394](https://bigcommercecloud.atlassian.net/browse/PHPMNT-394)

## What/Why?
Upgrade to Node.js to v26 to stay up to date. Node 20 is EOL

## Rollout/Rollback
Merge / revert

## Testing
CI on this PR

[PHPMNT-394]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ