### PR TITLE
perf(core): PHPMNT-394 Reduce per-call overhead on cache hits

### DIFF
--- a/src/cache-key-resolver.ts
+++ b/src/cache-key-resolver.ts
@@ -39,7 +39,7 @@ export default class CacheKeyResolver {
   }
 
   getKey(...args: any[]): string {
-    const { index, map: resolvedMap, parentMap } = this._resolveMap(...args);
+    const { index, map: resolvedMap, parentMap } = this._resolveMap(args);
     let map: TerminalCacheKeyMap;
 
     if (!resolvedMap) {
@@ -69,12 +69,12 @@ export default class CacheKeyResolver {
   }
 
   getUsedCount(...args: any[]): number {
-    const { map } = this._resolveMap(...args);
+    const { map } = this._resolveMap(args);
 
     return map && isTerminalCacheKeyMap(map) ? map.usedCount : 0;
   }
 
-  private _resolveMap(...args: any[]): ResolveResult {
+  private _resolveMap(args: any[]): ResolveResult {
     let index = 0;
     let parentMap = this._map;
 

--- a/src/is-shallow-equal.ts
+++ b/src/is-shallow-equal.ts
@@ -12,5 +12,13 @@ function compareNaN(valueA: any, valueB: any): boolean | undefined {
  * every call would create a new cache entry.
  */
 export default function isShallowEqual(valueA: any, valueB: any): boolean {
+  // Fast path: strictly equal values (the overwhelmingly common case for
+  // cache hits) and NaN pairs can be answered without entering
+  // shallowequal, which would otherwise route every comparison through
+  // the customizer.
+  if (valueA === valueB || (Number.isNaN(valueA) && Number.isNaN(valueB))) {
+    return true;
+  }
+
   return shallowEqual(valueA, valueB, compareNaN);
 }


### PR DESCRIPTION
Jira: [PHPMNT-394](https://bigcommercecloud.atlassian.net/browse/PHPMNT-394)

## What/Why?
Two changes to the hot path, benchmarked with 2M cache hits on a 3-argument key:

1. Fast path in `isShallowEqual`: I made performance worse in #63 where everything now goes through `shallowequal`
2. Pass argument arrays directly to `_resolveMap`: `getKey(...args)` immediately re-spread into `_resolveMap(...args)`, which on the ES5 compile target means an extra array copy plus `.apply()` on every call. Passing the array takes the benchmark to **40ms**

Net: 515ms -> 40ms (~13x) for repeated hits, without behaviour changes

## Rollout/Rollback
Merge / revert

## Testing
Tests still pass! And the above benchmarks were run on node 26

[PHPMNT-394]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ