### PR TITLE
fix(core): PHPMNT-394 Normalise maxSize so invalid values cannot disable memoization

### DIFF
--- a/src/cache-key-resolver.spec.ts
+++ b/src/cache-key-resolver.spec.ts
@@ -239,6 +239,40 @@ describe('CacheKeyResolver', () => {
     expect(resolver.getKey('hello')).toBe('1');
   });
 
+  it('treats a maxSize below one as no limit', () => {
+    const fractional = new CacheKeyResolver({ maxSize: 0.5 });
+
+    expect(fractional.getKey('a')).toBe('1');
+    expect(fractional.getKey('a')).toBe('1');
+
+    const negative = new CacheKeyResolver({ maxSize: -1 });
+
+    expect(negative.getKey('a')).toBe('1');
+    expect(negative.getKey('a')).toBe('1');
+  });
+
+  it('treats a non-finite maxSize as no limit', () => {
+    const infinite = new CacheKeyResolver({ maxSize: Infinity });
+
+    expect(infinite.getKey('a')).toBe('1');
+    expect(infinite.getKey('a')).toBe('1');
+
+    // With "no limit" the resolver should not track keys for expiry at all
+    // eslint-disable-next-line no-underscore-dangle
+    expect((infinite as any)._usedMaps.size).toBe(0);
+  });
+
+  it('floors a fractional maxSize above one', () => {
+    const resolver = new CacheKeyResolver({ maxSize: 2.7 });
+
+    expect(resolver.getKey('a')).toBe('1');
+    expect(resolver.getKey('b')).toBe('2');
+    expect(resolver.getKey('c')).toBe('3');
+
+    // maxSize 2.7 behaves as 2, so ('a') has expired by now
+    expect(resolver.getKey('a')).toBe('4');
+  });
+
   it('returns cache key used count', () => {
     const resolver = new CacheKeyResolver();
 

--- a/src/cache-key-resolver.ts
+++ b/src/cache-key-resolver.ts
@@ -35,7 +35,13 @@ export default class CacheKeyResolver {
     // values fall back to the defaults instead of overriding them
     const { isEqual = isShallowEqual, maxSize = 0, onExpire = noop } = options ?? {};
 
-    this._options = { isEqual, maxSize, onExpire };
+    // A fractional maxSize would otherwise expire a key on every call,
+    // negative and NaN values are meaningless, and Infinity would track
+    // every key without ever expiring one. Floor fractions and treat
+    // anything below 1 or non-finite as "no limit".
+    const normalizedMaxSize = Number.isFinite(maxSize) ? Math.max(0, Math.floor(maxSize)) : 0;
+
+    this._options = { isEqual, maxSize: normalizedMaxSize, onExpire };
   }
 
   getKey(...args: any[]): string {

--- a/src/memoize.spec.ts
+++ b/src/memoize.spec.ts
@@ -72,6 +72,16 @@ describe('memoize', () => {
     expect(format).toHaveBeenCalledTimes(1);
   });
 
+  it('still memoizes if maxSize is fractional or negative', () => {
+    const add = jest.fn((a: number, b: number) => a + b);
+    const memoizedAdd = memoize(add, { maxSize: 0.5 });
+
+    memoizedAdd(1, 1);
+    memoizedAdd(1, 1);
+
+    expect(add).toHaveBeenCalledTimes(1);
+  });
+
   it('uses custom equality function to compare arguments', () => {
     const getId = jest.fn((person: { id: number; name: string }) => person.id);
     const memoizedGetId = memoize(getId, {


### PR DESCRIPTION
Jira: [PHPMNT-394](https://bigcommercecloud.atlassian.net/browse/PHPMNT-394)

## What/Why?
A fractional or negative `maxSize` silently turns memoization off entirely:

```ts
const memoized = memoize(fn, { maxSize: 0.5 });
memoized(1, 1); // fn runs
memoized(1, 1); // fn runs again — every call is a miss
```

With `maxSize: 0.5`, the LRU set (size 1 after the first call) always "exceeds" the limit, so the key that was just issued is immediately expired — every call recomputes and the consumer gets no signal that anything is wrong. Negative and NaN values behave the same way, and `Infinity` has the opposite problem: every key is tracked for expiry but none ever expires, so the tracking set grows forever. The `maxSize` type is `number`, so a computed value can hit any of these without a type error.

Fix: the resolver now floors fractions and treats anything below 1 or non-finite as "no limit" (`Number.isFinite(maxSize) ? Math.max(0, Math.floor(maxSize)) : 0`). So `2.7` behaves as `2`, while `0.5`, `-1`, `NaN`, and `Infinity` behave as the default unlimited cache — degraded gracefully instead of silently misbehaving.

## Rollout/Rollback
Merge / revert

## Testing
Tests added at the resolver level (below-one values, non-finite values, fractional flooring) and the memoize level.

[PHPMNT-394]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ