### PR TITLE
perf(core): PHPMNT-394 Index sibling maps by value for constant-time lookup

### DIFF
--- a/src/cache-key-maps.ts
+++ b/src/cache-key-maps.ts
@@ -1,9 +1,15 @@
 export interface RootCacheKeyMap {
   maps: ChildCacheKeyMap[];
+  // Index of child maps by their value, for constant-time lookup when the
+  // default comparison is in use. Values compared by identity (or NaN)
+  // resolve through this index; only shallowly-equal-but-distinct objects
+  // need to fall back to scanning `maps`.
+  valueIndex?: Map<any, ChildCacheKeyMap>;
 }
 
 export interface IntermediateCacheKeyMap {
   maps: ChildCacheKeyMap[];
+  valueIndex?: Map<any, ChildCacheKeyMap>;
   parentMap: RootCacheKeyMap | IntermediateCacheKeyMap;
   usedCount: number;
   value: any;

--- a/src/cache-key-resolver.spec.ts
+++ b/src/cache-key-resolver.spec.ts
@@ -1,5 +1,10 @@
 import CacheKeyResolver from './cache-key-resolver';
 
+const isCaseInsensitivelyEqual = (valueA: any, valueB: any): boolean =>
+  typeof valueA === 'string' && typeof valueB === 'string'
+    ? valueA.toLowerCase() === valueB.toLowerCase()
+    : valueA === valueB;
+
 describe('CacheKeyResolver', () => {
   it('returns same cache key if params are equal', () => {
     const resolver = new CacheKeyResolver();
@@ -237,6 +242,57 @@ describe('CacheKeyResolver', () => {
 
     expect(resolver.getKey('hello')).toBe('1');
     expect(resolver.getKey('hello')).toBe('1');
+  });
+
+  it('resolves and expires keys correctly across many sibling values', () => {
+    const resolver = new CacheKeyResolver({ maxSize: 50 });
+
+    // Enough siblings to cross the width threshold of the value index
+    for (let index = 0; index < 50; index++) {
+      expect(resolver.getKey(`arg${index}`)).toBe(`${index + 1}`);
+    }
+
+    // Every key still resolves to the same value on a second pass
+    for (let index = 0; index < 50; index++) {
+      expect(resolver.getKey(`arg${index}`)).toBe(`${index + 1}`);
+    }
+
+    // A new key expires the least recently used one ('arg0'), which then
+    // resolves to a fresh key. Re-adding it pushes the cache over the
+    // limit again, expiring the next oldest ('arg1').
+    expect(resolver.getKey('another')).toBe('51');
+    expect(resolver.getKey('arg0')).toBe('52');
+    expect(resolver.getKey('arg0')).toBe('52');
+    expect(resolver.getKey('arg1')).toBe('53');
+
+    // Keys that were never expired keep resolving to their original value
+    expect(resolver.getKey('arg3')).toBe('4');
+  });
+
+  it('matches shallowly equal objects among many sibling values', () => {
+    const resolver = new CacheKeyResolver();
+
+    for (let index = 0; index < 20; index++) {
+      resolver.getKey({ id: index });
+    }
+
+    // A different instance with the same shape should still resolve to the
+    // existing key, even though the sibling level is wide
+    expect(resolver.getKey({ id: 0 })).toBe('1');
+    expect(resolver.getKey({ id: 19 })).toBe('20');
+  });
+
+  it('respects a custom isEqual among many sibling values', () => {
+    const resolver = new CacheKeyResolver({ isEqual: isCaseInsensitivelyEqual });
+
+    for (let index = 0; index < 20; index++) {
+      resolver.getKey(`arg${index}`);
+    }
+
+    // A custom comparison can equate values that are not identical, so
+    // these must resolve through it even when the sibling level is wide
+    expect(resolver.getKey('ARG0')).toBe('1');
+    expect(resolver.getKey('ARG19')).toBe('20');
   });
 
   it('returns cache key used count', () => {

--- a/src/cache-key-resolver.ts
+++ b/src/cache-key-resolver.ts
@@ -29,6 +29,7 @@ export default class CacheKeyResolver {
   private _map: RootCacheKeyMap = { maps: [] };
   private _usedMaps = new Set<TerminalCacheKeyMap>();
   private _options: Required<CacheKeyResolverOptions>;
+  private _useValueIndex: boolean;
 
   constructor(options?: CacheKeyResolverOptions) {
     // Use destructuring defaults so that explicitly-undefined option
@@ -36,6 +37,13 @@ export default class CacheKeyResolver {
     const { isEqual = isShallowEqual, maxSize = 0, onExpire = noop } = options ?? {};
 
     this._options = { isEqual, maxSize, onExpire };
+
+    // Maps compare keys the same way the default comparison treats
+    // everything except shallowly-equal-but-distinct objects, so sibling
+    // maps can be indexed by value for constant-time lookup. A custom
+    // comparison could equate values a Map would keep apart, so the index
+    // can only be used with the default one.
+    this._useValueIndex = isEqual === isShallowEqual;
   }
 
   getKey(...args: any[]): string {
@@ -86,6 +94,30 @@ export default class CacheKeyResolver {
     // argument at its depth.
     while (parentMap.maps.length) {
       let isMatched = false;
+      const arg = args[index];
+
+      // For a handful of siblings a linear scan is cheaper than a Map
+      // lookup, so the index only takes over once a level gets wide.
+      if (this._useValueIndex && parentMap.maps.length > 8) {
+        const indexedMap = parentMap.valueIndex?.get(arg);
+
+        if (indexedMap) {
+          if (args.length === 0 || index === args.length - 1) {
+            return { index, map: indexedMap, parentMap };
+          }
+
+          parentMap = indexedMap;
+          index++;
+          continue;
+        }
+
+        // Under the default comparison only non-null objects can match a
+        // map without being identical to its value, so for anything else
+        // an index miss is a definitive miss.
+        if (typeof arg !== 'object' || arg === null) {
+          break;
+        }
+      }
 
       for (let mapIndex = 0; mapIndex < parentMap.maps.length; mapIndex++) {
         const map = parentMap.maps[mapIndex];
@@ -142,6 +174,10 @@ export default class CacheKeyResolver {
       // next time when the function is called with the same set of
       // arguments.
       parentMap.maps.unshift(map);
+
+      if (this._useValueIndex) {
+        (parentMap.valueIndex ?? (parentMap.valueIndex = new Map())).set(map.value, map);
+      }
 
       parentMap = map;
       index++;
@@ -201,6 +237,7 @@ export default class CacheKeyResolver {
     }
 
     parentMap.maps.splice(parentMap.maps.indexOf(map), 1);
+    parentMap.valueIndex?.delete(map.value);
 
     // Also remove ancestors that no longer lead to any cache key,
     // otherwise they would accumulate indefinitely as keys expire.


### PR DESCRIPTION
Jira: [PHPMNT-394](https://bigcommercecloud.atlassian.net/browse/PHPMNT-394)

## What/Why?
Turns out every cache lookup scans the sibling values one by one with `isEqual`. That's fine when a function only ever sees a handful of different arguments, but performance gets bad with a big cache: cycling 200k calls through 1000 cached keys took a solid **30 seconds** on my machine

So this adds a `Map` index per level of the key tree. Map key equality is basically the same thing as our default comparison (identity, plus NaN equals NaN), so most lookups become a single `Map.get`. The edge cases are covered:

- objects that are shallowly equal but not the same instance can't be found through the Map, so those fall back to the old linear scan
- a custom `isEqual` could treat values as equal that a Map would keep apart, so the index is switched off entirely in that case, keeping behaviour
- levels with 8 or fewer siblings just keep scanning; a Map lookup is actually slower than a couple of `===` checks, so the common small-cache case stays at exactly the same speed (my first attempt without the threshold made it ~35% slower, hence the cutoff)

Numbers (best of 3 runs):

| scenario | before | after |
|---|---|---|
| 2M calls, same args every time, small cache | 40 ms | ~40 ms |
| 200k calls cycling through 1000 cached keys | 30,716 ms | **~27 ms** |
| 200k calls with fresh shallow-equal objects | 4.8 s | 4.8 s (scan-bound by design) |

## Rollout/Rollback
Merge / revert

## Testing
Existing tests pass, and new tests were added. And this was tested with 250k randomised calls. There are no behavioural differences

[PHPMNT-394]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ